### PR TITLE
feat: implement real-time price inquiry API for Korean stocks

### DIFF
--- a/kispy/base.py
+++ b/kispy/base.py
@@ -1,5 +1,7 @@
+from datetime import datetime
 import logging
 import time
+from zoneinfo import ZoneInfo
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -47,3 +49,13 @@ class BaseAPI:
                 continue
             custom_resp.raise_for_status()
             return custom_resp
+        
+    def _parse_date(self, date_str: str, zone_info: ZoneInfo | None = None) -> datetime:
+        date_str = date_str.replace("-", "")
+        try : 
+            result = datetime.strptime(date_str, "%Y%m%d")
+        except ValueError:
+            result = datetime.strptime(date_str, "%Y%m%d%H%M%S")
+        if zone_info:
+            result = result.replace(tzinfo=zone_info)
+        return result

--- a/kispy/domestic_stock/quote.py
+++ b/kispy/domestic_stock/quote.py
@@ -126,8 +126,9 @@ class QuoteAPI(BaseAPI):
             time = datetime.now().replace(second=0).strftime("%H%M%S")
 
         result: list[dict] = []
-        current_time = time
-        today = datetime.now().strftime("%Y%m%d")
+        now = datetime.now()
+        today = now.strftime("%Y%m%d")
+        current_time = time if time < now.strftime("%H%M%S") else now.strftime("%H%M%S")
 
         while limit is None or len(result) < limit:
             params={

--- a/kispy/domestic_stock/quote.py
+++ b/kispy/domestic_stock/quote.py
@@ -9,8 +9,8 @@ from kispy.base import BaseAPI
 
 class QuoteAPI(BaseAPI):
     def get_price(self, symbol: str) -> float:
-        """
-        주식 현재가 시세 API입니다. 실시간 시세를 원하신다면 웹소켓 API를 활용하세요.
+        """주식 현재가 시세 API[v1_국내주식-008]
+        입니다. 실시간 시세를 원하신다면 웹소켓 API를 활용하세요.
 
         Args:
             symbol (str): 종목코드
@@ -91,29 +91,30 @@ class QuoteAPI(BaseAPI):
     
     def get_stock_price_history_by_minute(
         self,
-        stock_code: str,
+        symbol: str,
         time: str | None = None,
-        include_hour: bool = False,
-        limit: int | None = 120,
+        limit: int | None = 30,
         desc: bool = False,
     ) -> list[dict]:
         """주식당일분봉조회[v1_국내주식-022]
         당일 분봉 데이터만 제공됩니다. (전일자 분봉 미제공)
 
         Args:
-            stock_code (str): 종목코드
+            symbol (str): 종목코드
             time (str | None): 조회 시작시간 (HHMMSS 형식, 예: "123000"은 12시 30분부터 조회) None인 경우 현재시각부터 조회
-            include_hour (bool): 시간외단일가여부 (True: 시간외단일가 포함, False: 미포함)
-            limit (int | None): 조회 건수 제한, None인 경우 가능한 모든 데이터 조회
-            desc (bool): 시간 역순 정렬 여부, 기본값은 False
+            limit (int): 조회 건수, 기본값 30건
+            desc (bool): 시간 역순 정렬 여부, 기본값은 False (False: 과거순 정렬, True: 최신순 정렬)
 
         Returns:
             list[dict]: 주식 분봉 시세
-            
+
         Note:
             - time에 미래 시각을 입력하면 현재 시각 기준으로 조회됩니다.
             - output2의 첫번째 배열의 체결량(cntg_vol)은 첫체결이 발생되기 전까지는 이전 분봉의 체결량이 표시됩니다.
-            - 한 번의 API 호출로 최대 120건의 데이터를 가져올 수 있으며, 여러 번 호출하여 더 많은 데이터를 가져올 수 있습니다.
+            - 한 번의 API 호출로 최대 30건의 데이터를 가져올 수 있으며, 여러 번 호출하여 더 많은 데이터를 가져올 수 있습니다.
+            - 개선 가능 사항 : 
+                - ETF, ETN의 분봉 데이터를 사용하여 국내 지수 분봉 데이터 추가 조회 가능
+                - 섹터/업종별 지수 추가 조회 가능
         """
         path = "uapi/domestic-stock/v1/quotations/inquire-time-itemchartprice"
         url = f"{self._url}/{path}"
@@ -126,40 +127,48 @@ class QuoteAPI(BaseAPI):
 
         result: list[dict] = []
         current_time = time
+        today = datetime.now().strftime("%Y%m%d")
 
         while limit is None or len(result) < limit:
-            resp = self._request(
-                "GET",
-                url,
-                headers=headers,
-                params={
-                    "FID_COND_MRKT_DIV_CODE": "J",
-                    "FID_INPUT_ISCD": stock_code,
-                    "FID_INPUT_HOUR_1": current_time,
-                    "FID_PW_DATA_INCU_YN": "Y" if include_hour else "N",
-                    "FID_ETC_CLS_CODE": "",
-                },
-            )
+            params={
+                "FID_COND_MRKT_DIV_CODE": "J", # 시장 분류 코드 (J : 주식)
+                "FID_INPUT_ISCD": symbol, # 종목코드
+                "FID_INPUT_HOUR_1": current_time, # 조회 시작 시간
+                "FID_ETC_CLS_CODE": "", # 종목 분류 코드 (기본값: 빈 문자열)
+                "FID_PW_DATA_INCU_YN": "N", # 데이터 포함 여부 (기본값: "N")
+            }
+
+            resp = self._request(method="get", url=url, headers=headers, params=params)
 
             records = list(resp.json["output2"])
             if not records:
                 break
 
+            for record in records:
+                record["stck_cntg_hour"] = self._parse_date(f"{today}{record['stck_cntg_hour']}")
+
+            if limit is not None:
+                remaining = limit - len(result)
+                records = records[:remaining]
+
             result.extend(records)
-            
+
+            if limit is not None and len(result) >= limit:
+                break
+
             last_record = records[-1]
             if "stck_cntg_hour" not in last_record:
                 break
-                
-            current_time = last_record["stck_cntg_hour"]
-            if limit and len(result) >= limit:
-                result = result[:limit]
-                break
+
+            current_time = self._get_next_keyb_minute(records)
 
         if not desc:
             result.reverse()
+
         return result
 
-
-    def _parse_date(self, date_str: str) -> datetime:
-        return datetime.strptime(date_str, "%Y-%m-%d")
+    def _get_next_keyb_minute(self, records: list[dict], period: int = 1) -> str:
+        last_record = records[-1]
+        last_time: datetime = last_record["stck_cntg_hour"]
+        next_time = last_time - timedelta(minutes=period)
+        return next_time.strftime("%H%M%S")

--- a/kispy/overseas_stock/quote.py
+++ b/kispy/overseas_stock/quote.py
@@ -269,10 +269,3 @@ class QuoteAPI(BaseAPI):
         last_time = datetime.strptime(last_time_str, "%Y%m%d%H%M%S")
         next_time = last_time - timedelta(minutes=int(period))
         return next_time.strftime("%Y%m%d%H%M%S")
-
-    def _parse_date(self, date_str: str, zone_info: ZoneInfo) -> datetime:
-        date_str = date_str.replace("-", "")
-        try:
-            return datetime.strptime(date_str, "%Y%m%d").replace(tzinfo=zone_info)
-        except ValueError:
-            return datetime.strptime(date_str, "%Y%m%d%H%M%S").replace(tzinfo=zone_info)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
 env =
+    KISPY_ACCOUNT_NO=test-01
     KISPY_APP_KEY=test
     KISPY_APP_SECRET=test
-    KISPY_ACCOUNT_NO=test-01

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
 env =
-    KISPY_ACCOUNT_NO=test-01
     KISPY_APP_KEY=test
     KISPY_APP_SECRET=test
+    KISPY_ACCOUNT_NO=test-01

--- a/tests/domestic_stock/test_quote.py
+++ b/tests/domestic_stock/test_quote.py
@@ -53,15 +53,49 @@ def test_get_stock_price_history_with_not_exists_in_start_date(auth: KisAuth):
 
 def test_get_stock_price_history_by_minute(auth: KisAuth):
     """
-    현재 시각부터 조회
+    현재 시각부터 조회 (기본 120건)
     """
     quote = KisClient(auth).domestic_stock.quote
     resp = quote.get_stock_price_history_by_minute(
         stock_code="005930",
     )
 
-    # API는 최대 30건까지만 제공
-    assert len(resp) <= 30
+    assert len(resp) <= 120
+    if len(resp) > 1:
+        # 기본적으로 과거순 정렬 (오름차순)
+        first_time = int(resp[0]["stck_cntg_hour"])
+        last_time = int(resp[-1]["stck_cntg_hour"])
+        assert first_time < last_time
+
+
+def test_get_stock_price_history_by_minute_with_limit(auth: KisAuth):
+    """
+    limit 파라미터 테스트
+    """
+    quote = KisClient(auth).domestic_stock.quote
+    resp = quote.get_stock_price_history_by_minute(
+        stock_code="005930",
+        limit=50,
+    )
+
+    assert len(resp) <= 50
+
+
+def test_get_stock_price_history_by_minute_with_desc(auth: KisAuth):
+    """
+    desc 파라미터 테스트 (시간 역순 정렬)
+    """
+    quote = KisClient(auth).domestic_stock.quote
+    resp = quote.get_stock_price_history_by_minute(
+        stock_code="005930",
+        desc=True,
+    )
+
+    if len(resp) > 1:
+        # 시간 역순 정렬 (내림차순)
+        first_time = int(resp[0]["stck_cntg_hour"])
+        last_time = int(resp[-1]["stck_cntg_hour"])
+        assert first_time > last_time
 
 
 def test_get_stock_price_history_by_minute_with_specific_time(auth: KisAuth):
@@ -74,11 +108,11 @@ def test_get_stock_price_history_by_minute_with_specific_time(auth: KisAuth):
         time="100000",
     )
 
-    assert len(resp) <= 30
+    assert len(resp) <= 120
     if resp:
-        # 10시 이후의 데이터만 있어야 함
-        first_time = int(resp[0]["stck_cntg_hour"])
-        assert first_time >= 100000
+        # 10시 이후의 데이터가 포함되어 있어야 함
+        last_time = int(resp[-1]["stck_cntg_hour"])
+        assert last_time >= 100000
 
 
 def test_get_stock_price_history_by_minute_with_include_hour(auth: KisAuth):
@@ -91,7 +125,7 @@ def test_get_stock_price_history_by_minute_with_include_hour(auth: KisAuth):
         include_hour=True,
     )
 
-    assert len(resp) <= 30
+    assert len(resp) <= 120
 
 
 def test_get_stock_price_history_by_minute_with_future_time(auth: KisAuth):
@@ -107,10 +141,10 @@ def test_get_stock_price_history_by_minute_with_future_time(auth: KisAuth):
         time=future_time,
     )
 
-    assert len(resp) <= 30
+    assert len(resp) <= 120
     if resp:
-        first_time = int(resp[0]["stck_cntg_hour"])
-        assert first_time <= int(future_time)
+        last_time = int(resp[-1]["stck_cntg_hour"])
+        assert last_time <= int(future_time)
 
 
 def test_get_stock_price_history_by_minute_not_exists(auth: KisAuth):

--- a/tests/domestic_stock/test_quote.py
+++ b/tests/domestic_stock/test_quote.py
@@ -49,3 +49,78 @@ def test_get_stock_price_history_with_not_exists_in_start_date(auth: KisAuth):
     resp = quote.get_stock_price_history("005930", "1960-01-01", "1985-01-05")
 
     assert len(resp) == 2
+
+
+def test_get_stock_price_history_by_minute(auth: KisAuth):
+    """
+    현재 시각부터 조회
+    """
+    quote = KisClient(auth).domestic_stock.quote
+    resp = quote.get_stock_price_history_by_minute(
+        stock_code="005930",
+    )
+
+    # API는 최대 30건까지만 제공
+    assert len(resp) <= 30
+
+
+def test_get_stock_price_history_by_minute_with_specific_time(auth: KisAuth):
+    """
+    오전 10시부터 조회
+    """
+    quote = KisClient(auth).domestic_stock.quote 
+    resp = quote.get_stock_price_history_by_minute(
+        stock_code="005930",
+        time="100000",
+    )
+
+    assert len(resp) <= 30
+    if resp:
+        # 10시 이후의 데이터만 있어야 함
+        first_time = int(resp[0]["stck_cntg_hour"])
+        assert first_time >= 100000
+
+
+def test_get_stock_price_history_by_minute_with_include_hour(auth: KisAuth):
+    """
+    시간외 거래 포함하여 조회
+    """
+    quote = KisClient(auth).domestic_stock.quote
+    resp = quote.get_stock_price_history_by_minute(
+        stock_code="005930",
+        include_hour=True,
+    )
+
+    assert len(resp) <= 30
+
+
+def test_get_stock_price_history_by_minute_with_future_time(auth: KisAuth):
+    """
+    미래 시각 입력 시 현재 시각으로 조회됨
+    """
+    quote = KisClient(auth).domestic_stock.quote
+    current_hour = datetime.now().strftime("%H")
+    future_time = f"{int(current_hour)+1:02d}0000"  # 현재보다 1시간 뒤
+    
+    resp = quote.get_stock_price_history_by_minute(
+        stock_code="005930",
+        time=future_time,
+    )
+
+    assert len(resp) <= 30
+    if resp:
+        first_time = int(resp[0]["stck_cntg_hour"])
+        assert first_time <= int(future_time)
+
+
+def test_get_stock_price_history_by_minute_not_exists(auth: KisAuth):
+    """
+    장 시작 전 시간으로 조회 시 데이터가 없어야 함
+    """
+    quote = KisClient(auth).domestic_stock.quote
+    resp = quote.get_stock_price_history_by_minute(
+        stock_code="005930",
+        time="040000",  # 새벽 4시
+    )
+
+    assert resp == []

--- a/tests/domestic_stock/test_quote.py
+++ b/tests/domestic_stock/test_quote.py
@@ -51,7 +51,6 @@ def test_get_stock_price_history_with_not_exists_in_start_date(auth: KisAuth):
     assert len(resp) == 2
 
 
-@freeze_time("2024-01-03 14:30:00", tz_offset=9)  # KST 14:30
 def test_get_stock_price_history_by_minute(auth: KisAuth):
     """현재 시각부터 기본 건수(30건) 조회"""
     quote = KisClient(auth).domestic_stock.quote
@@ -62,7 +61,6 @@ def test_get_stock_price_history_by_minute(auth: KisAuth):
     assert len(resp) == 30
 
 
-@freeze_time("2024-01-03 14:30:00", tz_offset=9)  # KST 14:30
 def test_get_stock_price_history_by_minute_with_desc(auth: KisAuth):
     """desc=True일 때 최신순(내림차순) 정렬"""
     quote = KisClient(auth).domestic_stock.quote
@@ -78,7 +76,6 @@ def test_get_stock_price_history_by_minute_with_desc(auth: KisAuth):
         assert first_time > last_time
 
 
-@freeze_time("2024-01-03 14:30:00", tz_offset=9)  # KST 14:30
 def test_get_stock_price_history_by_minute_with_limit(auth: KisAuth):
     """limit 파라미터 테스트"""
     quote = KisClient(auth).domestic_stock.quote
@@ -89,7 +86,6 @@ def test_get_stock_price_history_by_minute_with_limit(auth: KisAuth):
 
     assert len(resp) == 50
 
-@freeze_time("2024-01-03 14:30:00", tz_offset=9)  # KST 14:30
 def test_get_stock_price_history_by_minute_with_specific_time(auth: KisAuth):
     """특정 시각부터 조회"""
     quote = KisClient(auth).domestic_stock.quote 
@@ -101,7 +97,19 @@ def test_get_stock_price_history_by_minute_with_specific_time(auth: KisAuth):
     assert len(resp) == 30
     assert resp[-1]["stck_cntg_hour"].hour == 10
 
-@freeze_time("2024-01-03 04:00:00", tz_offset=9)  # KST 04:00
+def test_get_stock_price_history_by_minute_with_future_time(auth: KisAuth):
+    """미래 시간으로 조회시 현재 시간으로 조회"""
+    quote = KisClient(auth).domestic_stock.quote
+    now = datetime.now()
+    future = (now + timedelta(hours=1)).strftime("%H%M%S")
+    resp = quote.get_stock_price_history_by_minute(
+        symbol="005930",
+        time=future,
+    )
+
+    assert len(resp) == 30
+    assert resp[-1]["stck_cntg_hour"].hour == now.hour
+
 def test_get_stock_price_history_by_minute_not_exists(auth: KisAuth):
     """장 시작 전 시간으로 조회 시 데이터가 없어야 함"""
     quote = KisClient(auth).domestic_stock.quote


### PR DESCRIPTION
<details>
<summary>pytest 완료</summary>
<div markdown="1">
pytest tests/domestic_stock/test_quote.py -v

========================================================================== test session starts ==========================================================================
platform darwin -- Python 3.11.0, pytest-8.3.4, pluggy-1.5.0 -- /Users/oeyh98/.pyenv/versions/3.11.0/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/oeyh98/dev/Quantus/kispy
configfile: pytest.ini
plugins: env-1.1.5
collected 10 items                                                                                                                                                      

tests/domestic_stock/test_quote.py::test_get_stock_price_history PASSED                                                                                           [ 10%]
tests/domestic_stock/test_quote.py::test_get_stock_price_history_with_empty PASSED                                                                                [ 20%]
tests/domestic_stock/test_quote.py::test_get_stock_price_history_with_end_date_none PASSED                                                                        [ 30%]
tests/domestic_stock/test_quote.py::test_get_stock_price_history_with_end_date_future PASSED                                                                      [ 40%]
tests/domestic_stock/test_quote.py::test_get_stock_price_history_with_not_exists_in_start_date PASSED                                                             [ 50%]
tests/domestic_stock/test_quote.py::test_get_stock_price_history_by_minute PASSED                                                                                 [ 60%]
tests/domestic_stock/test_quote.py::test_get_stock_price_history_by_minute_with_specific_time PASSED                                                              [ 70%]
tests/domestic_stock/test_quote.py::test_get_stock_price_history_by_minute_with_include_hour PASSED                                                               [ 80%]
tests/domestic_stock/test_quote.py::test_get_stock_price_history_by_minute_with_future_time PASSED                                                                [ 90%]
tests/domestic_stock/test_quote.py::test_get_stock_price_history_by_minute_not_exists PASSED                                                                      [100%]

========================================================================== 10 passed in 0.52s ===========================================================================
</div>
</details>


<details>
<summary>외부 API 연결 테스트 완료</summary>
<div markdown="1">
python test.py

현재 시각 기준 조회:
현재 시각: 2025-01-06 17:25:20.759189
데이터 개수: 30
첫 번째 데이터: {'stck_bsop_date': '20250106', 'stck_cntg_hour': '172500', 'stck_prpr': '55900', 'stck_oprc': '55900', 'stck_hgpr': '55900', 'stck_lwpr': '55900', 'cntg_vol': '1078604', 'acml_tr_pbmn': '1048547839700'}

오전 10시부터 조회:
데이터 개수: 30
첫 번째 데이터: {'stck_bsop_date': '20250106', 'stck_cntg_hour': '100000', 'stck_prpr': '55000', 'stck_oprc': '55000', 'stck_hgpr': '55000', 'stck_lwpr': '54900', 'cntg_vol': '19678', 'acml_tr_pbmn': '221505825000'}

시간외 거래 포함 조회:
데이터 개수: 30
첫 번째 데이터: {'stck_bsop_date': '20250106', 'stck_cntg_hour': '172500', 'stck_prpr': '55900', 'stck_oprc': '55900', 'stck_hgpr': '55900', 'stck_lwpr': '55900', 'cntg_vol': '1078604', 'acml_tr_pbmn': '1048547839700'}
</div>
</details>