### PR TITLE
chore: fix test and lint baseline

### DIFF
--- a/kispy/base.py
+++ b/kispy/base.py
@@ -1,11 +1,11 @@
-from datetime import datetime
 import logging
 import time
-from zoneinfo import ZoneInfo
+from datetime import datetime
 
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
+from zoneinfo import ZoneInfo
 
 from kispy.auth import KisAuth
 from kispy.constants import REAL_URL, VIRTUAL_URL
@@ -49,10 +49,10 @@ class BaseAPI:
                 continue
             custom_resp.raise_for_status()
             return custom_resp
-        
+
     def _parse_date(self, date_str: str, zone_info: ZoneInfo | None = None) -> datetime:
         date_str = date_str.replace("-", "")
-        try : 
+        try:
             result = datetime.strptime(date_str, "%Y%m%d")
         except ValueError:
             result = datetime.strptime(date_str, "%Y%m%d%H%M%S")

--- a/kispy/domestic_stock/quote.py
+++ b/kispy/domestic_stock/quote.py
@@ -88,7 +88,7 @@ class QuoteAPI(BaseAPI):
             cur_end_date = datetime.strptime(items[-1]["stck_bsop_date"], "%Y%m%d") - timedelta(days=1)
 
         return result
-    
+
     def get_stock_price_history_by_minute(
         self,
         symbol: str,
@@ -101,7 +101,8 @@ class QuoteAPI(BaseAPI):
 
         Args:
             symbol (str): 종목코드
-            time (str | None): 조회 시작시간 (HHMMSS 형식, 예: "123000"은 12시 30분부터 조회) None인 경우 현재시각부터 조회
+            time (str | None): 조회 시작시간 (HHMMSS 형식, 예: "123000"은 12시 30분부터 조회)
+                None인 경우 현재시각부터 조회
             limit (int): 조회 건수, 기본값 30건
             desc (bool): 시간 역순 정렬 여부, 기본값은 False (False: 과거순 정렬, True: 최신순 정렬)
 
@@ -111,8 +112,9 @@ class QuoteAPI(BaseAPI):
         Note:
             - time에 미래 시각을 입력하면 현재 시각 기준으로 조회됩니다.
             - output2의 첫번째 배열의 체결량(cntg_vol)은 첫체결이 발생되기 전까지는 이전 분봉의 체결량이 표시됩니다.
-            - 한 번의 API 호출로 최대 30건의 데이터를 가져올 수 있으며, 여러 번 호출하여 더 많은 데이터를 가져올 수 있습니다.
-            - 개선 가능 사항 : 
+            - 한 번의 API 호출로 최대 30건의 데이터를 가져올 수 있으며,
+              여러 번 호출하여 더 많은 데이터를 가져올 수 있습니다.
+            - 개선 가능 사항 :
                 - ETF, ETN의 분봉 데이터를 사용하여 국내 지수 분봉 데이터 추가 조회 가능
                 - 섹터/업종별 지수 추가 조회 가능
         """
@@ -131,12 +133,12 @@ class QuoteAPI(BaseAPI):
         current_time = time if time < now.strftime("%H%M%S") else now.strftime("%H%M%S")
 
         while limit is None or len(result) < limit:
-            params={
-                "FID_COND_MRKT_DIV_CODE": "J", # 시장 분류 코드 (J : 주식)
-                "FID_INPUT_ISCD": symbol, # 종목코드
-                "FID_INPUT_HOUR_1": current_time, # 조회 시작 시간
-                "FID_ETC_CLS_CODE": "", # 종목 분류 코드 (기본값: 빈 문자열)
-                "FID_PW_DATA_INCU_YN": "N", # 데이터 포함 여부 (기본값: "N")
+            params = {
+                "FID_COND_MRKT_DIV_CODE": "J",  # 시장 분류 코드 (J : 주식)
+                "FID_INPUT_ISCD": symbol,  # 종목코드
+                "FID_INPUT_HOUR_1": current_time,  # 조회 시작 시간
+                "FID_ETC_CLS_CODE": "",  # 종목 분류 코드 (기본값: 빈 문자열)
+                "FID_PW_DATA_INCU_YN": "N",  # 데이터 포함 여부 (기본값: "N")
             }
 
             resp = self._request(method="get", url=url, headers=headers, params=params)

--- a/kispy/overseas_stock/quote.py
+++ b/kispy/overseas_stock/quote.py
@@ -4,8 +4,6 @@
 
 from datetime import datetime, timedelta
 
-from zoneinfo import ZoneInfo
-
 from kispy.base import BaseAPI
 from kispy.constants import ExchangeCode, TimeZoneMap
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,4 +11,6 @@ def auth():
     secret = os.getenv("KISPY_APP_SECRET")
     account_no = os.getenv("KISPY_ACCOUNT_NO")
     assert app_key and secret and account_no, "KISPY_APP_KEY, KISPY_APP_SECRET, KISPY_ACCOUNT_NO must be set"
+    if app_key == "test" or secret == "test" or account_no == "test-01":
+        pytest.skip("KIS integration credentials are not configured")
     return KisAuth(app_key=app_key, secret=secret, account_no=account_no, is_real=True)

--- a/tests/domestic_stock/test_quote.py
+++ b/tests/domestic_stock/test_quote.py
@@ -86,9 +86,10 @@ def test_get_stock_price_history_by_minute_with_limit(auth: KisAuth):
 
     assert len(resp) == 50
 
+
 def test_get_stock_price_history_by_minute_with_specific_time(auth: KisAuth):
     """특정 시각부터 조회"""
-    quote = KisClient(auth).domestic_stock.quote 
+    quote = KisClient(auth).domestic_stock.quote
     resp = quote.get_stock_price_history_by_minute(
         symbol="005930",
         time="100000",  # 오전 10시
@@ -96,6 +97,7 @@ def test_get_stock_price_history_by_minute_with_specific_time(auth: KisAuth):
 
     assert len(resp) == 30
     assert resp[-1]["stck_cntg_hour"].hour == 10
+
 
 def test_get_stock_price_history_by_minute_with_future_time(auth: KisAuth):
     """미래 시간으로 조회시 현재 시간으로 조회"""
@@ -109,6 +111,7 @@ def test_get_stock_price_history_by_minute_with_future_time(auth: KisAuth):
 
     assert len(resp) == 30
     assert resp[-1]["stck_cntg_hour"].hour == now.hour
+
 
 def test_get_stock_price_history_by_minute_not_exists(auth: KisAuth):
     """장 시작 전 시간으로 조회 시 데이터가 없어야 함"""


### PR DESCRIPTION
## 배경
PR #2 이후 다음 작업을 진행하기 전에 repo-wide pre-commit/lint/test baseline을 green으로 맞춥니다. 기존 실패는 두 가지였습니다.

- `poetry run ruff check .`가 기존 whitespace/import/line-length 이슈로 실패
- `poetry run pytest tests/domestic_stock`가 pytest-env placeholder credential(`test`)로 실제 KIS 토큰 발급을 시도해 `EGW00103 유효하지 않은 AppKey`로 실패

## 변경 내용
- pre-commit/ruff가 지적한 기존 포맷 이슈 정리
  - `kispy/base.py`
  - `kispy/domestic_stock/quote.py`
  - `kispy/overseas_stock/quote.py`
  - `tests/domestic_stock/test_quote.py`
- `tests/conftest.py`의 `auth` fixture가 placeholder credential이면 실 API 호출 대신 skip하도록 변경

## 리뷰 포커스
- placeholder credential에서 integration-style KIS tests를 skip하는 정책이 적절한지
- 실제 KIS credential을 제공한 환경에서는 기존처럼 API 호출 테스트가 실행되는지
- 이번 PR이 포맷/테스트 baseline 정리에만 머무르는지

## 테스트
- `poetry run pytest` ✅ 18 passed, 33 skipped
- `poetry run pytest tests/domestic_stock` ✅ 5 passed, 11 skipped
- `poetry run ruff check .` ✅
- `poetry run pre-commit run --all-files` ✅
