### PR TITLE
feat: add krx nxt market data probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,17 @@ reserved_krx_preopen_buy = client.domestic_stock.order.prepare_reservation_order
 # 로그에는 계좌번호를 가린 payload만 남기세요.
 print(krx_preopen_buy.redacted_body())
 
+# KRX/NXT 시장 데이터 no-trade dry-run
+overtime_quote = client.domestic_stock.quote.prepare_overtime_asking_price("005930")
+preopen_balance_rank = client.domestic_stock.quote.prepare_after_hour_balance()
+nxt_asking_price = client.domestic_stock.realtime.prepare_nxt_asking_price_subscription("005930")
+nxt_trade = client.domestic_stock.realtime.prepare_nxt_trade_subscription("005930")
+nxt_market_status = client.domestic_stock.realtime.prepare_nxt_market_status_subscription("005930")
+
+print(overtime_quote.params)
+print(preopen_balance_rank.params)
+print(nxt_asking_price.to_message())
+
 # 일별 시세 조회
 history = client.domestic_stock.quote.get_stock_price_history(
     stock_code="005930",

--- a/kispy/domestic_stock/__init__.py
+++ b/kispy/domestic_stock/__init__.py
@@ -2,9 +2,11 @@ from kispy.auth import KisAuth
 
 from .order import OrderAPI
 from .quote import QuoteAPI
+from .realtime import RealtimeAPI
 
 
 class DomesticStock:
     def __init__(self, auth: KisAuth):
         self.order = OrderAPI(auth)
         self.quote = QuoteAPI(auth)
+        self.realtime = RealtimeAPI()

--- a/kispy/domestic_stock/quote.py
+++ b/kispy/domestic_stock/quote.py
@@ -2,9 +2,19 @@
 - 기본적인 시세 정보 조회 (현재가, 호가, 체결, 일별 시세 등)
 """
 
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 
 from kispy.base import BaseAPI
+
+
+@dataclass(frozen=True)
+class PreparedDomesticQuoteRequest:
+    method: str
+    path: str
+    tr_id: str
+    params: dict[str, str]
+    tr_cont: str = ""
 
 
 class QuoteAPI(BaseAPI):
@@ -31,6 +41,58 @@ class QuoteAPI(BaseAPI):
 
         resp = self._request(method="get", url=url, headers=headers, params=params)
         return float(resp.json["output"]["stck_prpr"])
+
+    def prepare_overtime_asking_price(
+        self,
+        stock_code: str,
+        market_division: str = "J",
+    ) -> PreparedDomesticQuoteRequest:
+        return PreparedDomesticQuoteRequest(
+            method="get",
+            path="uapi/domestic-stock/v1/quotations/inquire-overtime-asking-price",
+            tr_id="FHPST02300400",
+            params={
+                "FID_COND_MRKT_DIV_CODE": market_division,
+                "FID_INPUT_ISCD": stock_code,
+            },
+        )
+
+    def get_overtime_asking_price(self, stock_code: str, market_division: str = "J") -> dict:
+        """국내주식 시간외호가[국내주식-077]."""
+        request = self.prepare_overtime_asking_price(stock_code=stock_code, market_division=market_division)
+        return self._send_prepared_quote_request(request)["output"]  # type: ignore[no-any-return]
+
+    def prepare_after_hour_balance(
+        self,
+        rank_sort: str = "1",
+        market_code: str = "0000",
+        tr_cont: str = "",
+    ) -> PreparedDomesticQuoteRequest:
+        return PreparedDomesticQuoteRequest(
+            method="get",
+            path="uapi/domestic-stock/v1/ranking/after-hour-balance",
+            tr_id="FHPST01760000",
+            tr_cont=tr_cont,
+            params={
+                "fid_input_price_1": "",
+                "fid_cond_mrkt_div_code": "J",
+                "fid_cond_scr_div_code": "20176",
+                "fid_rank_sort_cls_code": rank_sort,
+                "fid_div_cls_code": "0",
+                "fid_input_iscd": market_code,
+                "fid_trgt_exls_cls_code": "0",
+                "fid_trgt_cls_code": "0",
+                "fid_vol_cnt": "",
+                "fid_input_price_2": "",
+            },
+        )
+
+    def get_after_hour_balance(self, rank_sort: str = "1", market_code: str = "0000") -> list[dict]:
+        """국내주식 시간외잔량 순위[v1_국내주식-093]."""
+        request = self.prepare_after_hour_balance(rank_sort=rank_sort, market_code=market_code)
+        data = self._send_prepared_quote_request(request)
+        output = data.get("output", [])
+        return list(output) if isinstance(output, list) else [output]
 
     def get_stock_price_history(
         self,
@@ -175,3 +237,12 @@ class QuoteAPI(BaseAPI):
         last_time: datetime = last_record["stck_cntg_hour"]
         next_time = last_time - timedelta(minutes=period)
         return next_time.strftime("%H%M%S")
+
+    def _send_prepared_quote_request(self, request: PreparedDomesticQuoteRequest) -> dict:
+        url = f"{self._url}/{request.path}"
+        headers = self._auth.get_header()
+        headers["tr_id"] = request.tr_id
+        if request.tr_cont:
+            headers["tr_cont"] = request.tr_cont
+        resp = self._request(method=request.method, url=url, headers=headers, params=request.params)
+        return resp.json

--- a/kispy/domestic_stock/realtime.py
+++ b/kispy/domestic_stock/realtime.py
@@ -1,1 +1,200 @@
 """[국내주식] 실시간시세"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PreparedWebSocketSubscription:
+    tr_id: str
+    tr_type: str
+    params: dict[str, str]
+    columns: list[str]
+
+    def to_message(self, extra_headers: dict[str, str] | None = None) -> dict:
+        headers = {
+            "tr_type": self.tr_type,
+            "custtype": "P",
+        }
+        if extra_headers:
+            headers.update(extra_headers)
+
+        body_input = {"tr_id": self.tr_id}
+        body_input.update(self.params)
+        return {
+            "header": headers,
+            "body": {"input": body_input},
+        }
+
+
+class RealtimeAPI:
+    def prepare_nxt_asking_price_subscription(
+        self,
+        stock_code: str,
+        subscribe: bool = True,
+    ) -> PreparedWebSocketSubscription:
+        return PreparedWebSocketSubscription(
+            tr_id="H0NXASP0",
+            tr_type=_get_tr_type(subscribe),
+            params={"tr_key": stock_code},
+            columns=NXT_ASKING_PRICE_COLUMNS,
+        )
+
+    def prepare_nxt_trade_subscription(
+        self,
+        stock_code: str,
+        subscribe: bool = True,
+    ) -> PreparedWebSocketSubscription:
+        return PreparedWebSocketSubscription(
+            tr_id="H0NXCNT0",
+            tr_type=_get_tr_type(subscribe),
+            params={"tr_key": stock_code},
+            columns=NXT_TRADE_COLUMNS,
+        )
+
+    def prepare_nxt_market_status_subscription(
+        self,
+        stock_code: str,
+        subscribe: bool = True,
+    ) -> PreparedWebSocketSubscription:
+        return PreparedWebSocketSubscription(
+            tr_id="H0NXMKO0",
+            tr_type=_get_tr_type(subscribe),
+            params={"tr_key": stock_code},
+            columns=NXT_MARKET_STATUS_COLUMNS,
+        )
+
+
+def _get_tr_type(subscribe: bool) -> str:
+    return "1" if subscribe else "0"
+
+
+NXT_ASKING_PRICE_COLUMNS = [
+    "MKSC_SHRN_ISCD",
+    "BSOP_HOUR",
+    "HOUR_CLS_CODE",
+    "ASKP1",
+    "ASKP2",
+    "ASKP3",
+    "ASKP4",
+    "ASKP5",
+    "ASKP6",
+    "ASKP7",
+    "ASKP8",
+    "ASKP9",
+    "ASKP10",
+    "BIDP1",
+    "BIDP2",
+    "BIDP3",
+    "BIDP4",
+    "BIDP5",
+    "BIDP6",
+    "BIDP7",
+    "BIDP8",
+    "BIDP9",
+    "BIDP10",
+    "ASKP_RSQN1",
+    "ASKP_RSQN2",
+    "ASKP_RSQN3",
+    "ASKP_RSQN4",
+    "ASKP_RSQN5",
+    "ASKP_RSQN6",
+    "ASKP_RSQN7",
+    "ASKP_RSQN8",
+    "ASKP_RSQN9",
+    "ASKP_RSQN10",
+    "BIDP_RSQN1",
+    "BIDP_RSQN2",
+    "BIDP_RSQN3",
+    "BIDP_RSQN4",
+    "BIDP_RSQN5",
+    "BIDP_RSQN6",
+    "BIDP_RSQN7",
+    "BIDP_RSQN8",
+    "BIDP_RSQN9",
+    "BIDP_RSQN10",
+    "TOTAL_ASKP_RSQN",
+    "TOTAL_BIDP_RSQN",
+    "OVTM_TOTAL_ASKP_RSQN",
+    "OVTM_TOTAL_BIDP_RSQN",
+    "ANTC_CNPR",
+    "ANTC_CNQN",
+    "ANTC_VOL",
+    "ANTC_CNTG_VRSS",
+    "ANTC_CNTG_VRSS_SIGN",
+    "ANTC_CNTG_PRDY_CTRT",
+    "ACML_VOL",
+    "TOTAL_ASKP_RSQN_ICDC",
+    "TOTAL_BIDP_RSQN_ICDC",
+    "OVTM_TOTAL_ASKP_ICDC",
+    "OVTM_TOTAL_BIDP_ICDC",
+    "STCK_DEAL_CLS_CODE",
+    "KMID_PRC",
+    "KMID_TOTAL_RSQN",
+    "KMID_CLS_CODE",
+    "NMID_PRC",
+    "NMID_TOTAL_RSQN",
+    "NMID_CLS_CODE",
+]
+
+NXT_TRADE_COLUMNS = [
+    "MKSC_SHRN_ISCD",
+    "STCK_CNTG_HOUR",
+    "STCK_PRPR",
+    "PRDY_VRSS_SIGN",
+    "PRDY_VRSS",
+    "PRDY_CTRT",
+    "WGHN_AVRG_STCK_PRC",
+    "STCK_OPRC",
+    "STCK_HGPR",
+    "STCK_LWPR",
+    "ASKP1",
+    "BIDP1",
+    "CNTG_VOL",
+    "ACML_VOL",
+    "ACML_TR_PBMN",
+    "SELN_CNTG_CSNU",
+    "SHNU_CNTG_CSNU",
+    "NTBY_CNTG_CSNU",
+    "CTTR",
+    "SELN_CNTG_SMTN",
+    "SHNU_CNTG_SMTN",
+    "CNTG_CLS_CODE",
+    "SHNU_RATE",
+    "PRDY_VOL_VRSS_ACML_VOL_RATE",
+    "OPRC_HOUR",
+    "OPRC_VRSS_PRPR_SIGN",
+    "OPRC_VRSS_PRPR",
+    "HGPR_HOUR",
+    "HGPR_VRSS_PRPR_SIGN",
+    "HGPR_VRSS_PRPR",
+    "LWPR_HOUR",
+    "LWPR_VRSS_PRPR_SIGN",
+    "LWPR_VRSS_PRPR",
+    "BSOP_DATE",
+    "NEW_MKOP_CLS_CODE",
+    "TRHT_YN",
+    "ASKP_RSQN1",
+    "BIDP_RSQN1",
+    "TOTAL_ASKP_RSQN",
+    "TOTAL_BIDP_RSQN",
+    "VOL_TNRT",
+    "PRDY_SMNS_HOUR_ACML_VOL",
+    "PRDY_SMNS_HOUR_ACML_VOL_RATE",
+    "HOUR_CLS_CODE",
+    "MRKT_TRTM_CLS_CODE",
+    "VI_STND_PRC",
+]
+
+NXT_MARKET_STATUS_COLUMNS = [
+    "MKSC_SHRN_ISCD",
+    "TRHT_YN",
+    "TR_SUSP_REAS_CNTT",
+    "MKOP_CLS_CODE",
+    "ANTC_MKOP_CLS_CODE",
+    "MRKT_TRTM_CLS_CODE",
+    "DIVI_APP_CLS_CODE",
+    "ISCD_STAT_CLS_CODE",
+    "VI_CLS_CODE",
+    "OVTM_VI_CLS_CODE",
+    "EXCH_CLS_CODE",
+]

--- a/tests/domestic_stock/test_market_data_probe.py
+++ b/tests/domestic_stock/test_market_data_probe.py
@@ -1,0 +1,118 @@
+from types import SimpleNamespace
+
+from kispy.domestic_stock.quote import QuoteAPI
+from kispy.domestic_stock.realtime import RealtimeAPI
+
+
+def make_quote_api() -> QuoteAPI:
+    auth = SimpleNamespace(
+        is_real=True,
+        get_header=lambda: {"authorization": "Bearer token", "appkey": "key", "appsecret": "secret"},
+    )
+    return QuoteAPI(auth)
+
+
+def test_prepare_overtime_asking_price_request_matches_official_sample():
+    request = make_quote_api().prepare_overtime_asking_price("005930")
+
+    assert request.method == "get"
+    assert request.path == "uapi/domestic-stock/v1/quotations/inquire-overtime-asking-price"
+    assert request.tr_id == "FHPST02300400"
+    assert request.params == {
+        "FID_COND_MRKT_DIV_CODE": "J",
+        "FID_INPUT_ISCD": "005930",
+    }
+
+
+def test_get_overtime_asking_price_sends_prepared_request(monkeypatch):
+    api = make_quote_api()
+    captured = {}
+
+    def fake_request(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(json={"output": {"ovtm_askp1": "73000"}})
+
+    monkeypatch.setattr(api, "_request", fake_request)
+
+    response = api.get_overtime_asking_price("005930")
+
+    assert response == {"ovtm_askp1": "73000"}
+    assert captured["method"] == "get"
+    assert captured["headers"]["tr_id"] == "FHPST02300400"
+    assert captured["params"]["FID_INPUT_ISCD"] == "005930"
+
+
+def test_prepare_after_hour_balance_request_defaults_to_preopen_rank():
+    request = make_quote_api().prepare_after_hour_balance()
+
+    assert request.method == "get"
+    assert request.path == "uapi/domestic-stock/v1/ranking/after-hour-balance"
+    assert request.tr_id == "FHPST01760000"
+    assert request.params == {
+        "fid_input_price_1": "",
+        "fid_cond_mrkt_div_code": "J",
+        "fid_cond_scr_div_code": "20176",
+        "fid_rank_sort_cls_code": "1",
+        "fid_div_cls_code": "0",
+        "fid_input_iscd": "0000",
+        "fid_trgt_exls_cls_code": "0",
+        "fid_trgt_cls_code": "0",
+        "fid_vol_cnt": "",
+        "fid_input_price_2": "",
+    }
+
+
+def test_get_after_hour_balance_sends_preopen_rank_request(monkeypatch):
+    api = make_quote_api()
+    captured = {}
+
+    def fake_request(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(json={"output": [{"hts_kor_isnm": "삼성전자"}]})
+
+    monkeypatch.setattr(api, "_request", fake_request)
+
+    response = api.get_after_hour_balance()
+
+    assert response == [{"hts_kor_isnm": "삼성전자"}]
+    assert captured["headers"]["tr_id"] == "FHPST01760000"
+    assert captured["params"]["fid_rank_sort_cls_code"] == "1"
+
+
+def test_prepare_nxt_asking_price_subscription_message_matches_official_shape():
+    subscription = RealtimeAPI().prepare_nxt_asking_price_subscription("005930")
+
+    assert subscription.tr_id == "H0NXASP0"
+    assert subscription.tr_type == "1"
+    assert subscription.params == {"tr_key": "005930"}
+    assert subscription.to_message() == {
+        "header": {
+            "tr_type": "1",
+            "custtype": "P",
+        },
+        "body": {
+            "input": {
+                "tr_id": "H0NXASP0",
+                "tr_key": "005930",
+            }
+        },
+    }
+    assert "ASKP1" in subscription.columns
+    assert "KMID_PRC" in subscription.columns
+
+
+def test_prepare_nxt_trade_subscription_uses_trade_tr_id():
+    subscription = RealtimeAPI().prepare_nxt_trade_subscription("005930", subscribe=False)
+
+    assert subscription.tr_id == "H0NXCNT0"
+    assert subscription.tr_type == "0"
+    assert subscription.params == {"tr_key": "005930"}
+    assert "STCK_PRPR" in subscription.columns
+
+
+def test_prepare_nxt_market_status_subscription_uses_market_status_tr_id():
+    subscription = RealtimeAPI().prepare_nxt_market_status_subscription("005930")
+
+    assert subscription.tr_id == "H0NXMKO0"
+    assert subscription.params == {"tr_key": "005930"}
+    assert "MKOP_CLS_CODE" in subscription.columns


### PR DESCRIPTION
## 배경
KRX-NXT 시간외 차익 feasibility probe의 다음 단계로, 실주문 없이 KRX 시간외 read path와 NXT WebSocket subscription shape를 검증할 수 있는 no-trade/dry-run surface를 추가합니다.

공식 확인 기준(2026-07-09):
- KIS Developers API 문서/공지: https://apiportal.koreainvestment.com/apiservice-category, https://apiportal.koreainvestment.com/community
- KIS official samples latest local rev: `885dd4e`
- REST 시간외호가 sample: `inquire_overtime_asking_price` / `FHPST02300400`
- REST 시간외잔량 순위 sample: `after_hour_balance` / `FHPST01760000`, `fid_rank_sort_cls_code=1` 장전 시간외
- NXT WS samples: `H0NXASP0` 호가, `H0NXCNT0` 체결, `H0NXMKO0` 장운영정보

## 변경 내용
- 국내주식 quote dry-run request builder 추가
  - `prepare_overtime_asking_price()` / `get_overtime_asking_price()`
  - `prepare_after_hour_balance()` / `get_after_hour_balance()`
- 국내주식 NXT WebSocket subscription builder 추가
  - `prepare_nxt_asking_price_subscription()`
  - `prepare_nxt_trade_subscription()`
  - `prepare_nxt_market_status_subscription()`
  - official `data_fetch()`와 같은 `to_message()` shape 제공
- `DomesticStock.realtime` 접근 경로 추가
- README에 KRX/NXT market-data no-trade dry-run 예시 추가
- official sample request/subscription shape를 고정하는 unit tests 추가

## 리뷰 포커스
- KIS official samples 대비 REST `tr_id`, path, params가 맞는지
- NXT WS subscription message가 official `data_fetch()` shape와 맞는지
- 이 PR이 실제 WebSocket 연결/수신 루프가 아니라 no-trade probe용 shape builder 범위에 머무르는지
- 장전 시간외잔량 기본값 `fid_rank_sort_cls_code=1`이 probe 목적에 맞는지

## 테스트
- `poetry run pytest tests/domestic_stock/test_market_data_probe.py tests/domestic_stock/test_order.py` ✅ 12 passed
- `poetry run pytest tests/domestic_stock` ✅ 12 passed, 11 skipped
- `poetry run pytest` ✅ 25 passed, 33 skipped
- `poetry run ruff check .` ✅
- `poetry run pre-commit run --all-files` ✅
- commit hook pre-commit ✅
