### PR TITLE
feat: add overseas futures api surface

### DIFF
--- a/kispy/client.py
+++ b/kispy/client.py
@@ -15,6 +15,7 @@ from kispy.domestic_stock import DomesticStock
 from kispy.exceptions import InvalidSymbol
 from kispy.models.account import AccountSummary, Balance, Order, PendingOrder, Position
 from kispy.models.market import OHLCV, Symbol
+from kispy.overseas_futures import OverseasFutures
 from kispy.overseas_stock import OverseasStock
 from kispy.utils import get_symbol_map
 
@@ -46,6 +47,7 @@ class KisClient:
         self._url = REAL_URL if auth.is_real else VIRTUAL_URL
         self._auth = auth
         self.domestic_stock = DomesticStock(auth=self._auth)
+        self.overseas_futures = OverseasFutures(auth=self._auth)
         self.overseas_stock = OverseasStock(auth=self._auth)
 
 

--- a/kispy/overseas_futures/__init__.py
+++ b/kispy/overseas_futures/__init__.py
@@ -1,0 +1,12 @@
+from kispy.auth import KisAuth
+
+from .account import AccountAPI
+from .order import OrderAPI
+from .quote import QuoteAPI
+
+
+class OverseasFutures:
+    def __init__(self, auth: KisAuth):
+        self.account = AccountAPI(auth)
+        self.order = OrderAPI(auth)
+        self.quote = QuoteAPI(auth)

--- a/kispy/overseas_futures/account.py
+++ b/kispy/overseas_futures/account.py
@@ -1,0 +1,5 @@
+from kispy.base import BaseAPI
+
+
+class AccountAPI(BaseAPI):
+    pass

--- a/kispy/overseas_futures/order.py
+++ b/kispy/overseas_futures/order.py
@@ -1,0 +1,125 @@
+"""[해외선물옵션] 주문/계좌."""
+
+from dataclasses import dataclass
+
+from kispy.base import BaseAPI
+from kispy.constants import OrderSide
+from kispy.exceptions import KispyException
+
+
+@dataclass(frozen=True)
+class PreparedOverseasFuturesOrder:
+    method: str
+    path: str
+    tr_id: str
+    body: dict[str, str]
+
+    def redacted_body(self) -> dict[str, str]:
+        return {
+            **self.body,
+            "CANO": "***",
+            "ACNT_PRDT_CD": "***",
+        }
+
+
+class OrderAPI(BaseAPI):
+    def prepare_order(
+        self,
+        symbol: str,
+        side: OrderSide,
+        quantity: int,
+        price: float | str | None = None,
+        price_type: str = "1",
+        condition: str = "6",
+    ) -> PreparedOverseasFuturesOrder:
+        """해외선물옵션 주문[v1_해외선물-001]."""
+        return PreparedOverseasFuturesOrder(
+            method="post",
+            path="uapi/overseas-futureoption/v1/trading/order",
+            tr_id="OTFM3001U",
+            body={
+                "CANO": self._auth.cano,
+                "ACNT_PRDT_CD": self._auth.acnt_prdt_cd,
+                "OVRS_FUTR_FX_PDNO": symbol,
+                "SLL_BUY_DVSN_CD": _get_side_code(side),
+                "FM_LQD_USTL_CCLD_DT": "",
+                "FM_LQD_USTL_CCNO": "",
+                "PRIC_DVSN_CD": price_type,
+                "FM_LIMIT_ORD_PRIC": "" if price is None else str(price),
+                "FM_STOP_ORD_PRIC": "",
+                "FM_ORD_QTY": str(quantity),
+                "FM_LQD_LMT_ORD_PRIC": "",
+                "FM_LQD_STOP_ORD_PRIC": "",
+                "CCLD_CNDT_CD": condition,
+                "CPLX_ORD_DVSN_CD": "0",
+                "ECIS_RSVN_ORD_YN": "N",
+                "FM_HDGE_ORD_SCRN_YN": "N",
+            },
+        )
+
+    def create(
+        self,
+        symbol: str,
+        side: OrderSide,
+        quantity: int,
+        price: float | str | None = None,
+        price_type: str = "1",
+        condition: str = "6",
+    ) -> dict:
+        order = self.prepare_order(
+            symbol=symbol,
+            side=side,
+            quantity=quantity,
+            price=price,
+            price_type=price_type,
+            condition=condition,
+        )
+        return self._send_prepared_order(order)
+
+    def prepare_cancel_order(
+        self,
+        order_number: str,
+        order_date: str,
+        market_price_conversion: str = "N",
+    ) -> PreparedOverseasFuturesOrder:
+        """해외선물옵션 주문 취소[v1_해외선물-003]."""
+        return PreparedOverseasFuturesOrder(
+            method="post",
+            path="uapi/overseas-futureoption/v1/trading/order-rvsecncl",
+            tr_id="OTFM3003U",
+            body={
+                "CANO": self._auth.cano,
+                "ACNT_PRDT_CD": self._auth.acnt_prdt_cd,
+                "ORGN_ORD_DT": order_date,
+                "ORGN_ODNO": order_number,
+                "FM_LIMIT_ORD_PRIC": "",
+                "FM_STOP_ORD_PRIC": "",
+                "FM_LQD_LMT_ORD_PRIC": "",
+                "FM_LQD_STOP_ORD_PRIC": "",
+                "FM_HDGE_ORD_SCRN_YN": "N",
+                "FM_MKPR_CVSN_YN": market_price_conversion,
+            },
+        )
+
+    def cancel(self, order_number: str, order_date: str, market_price_conversion: str = "N") -> dict:
+        order = self.prepare_cancel_order(
+            order_number=order_number,
+            order_date=order_date,
+            market_price_conversion=market_price_conversion,
+        )
+        return self._send_prepared_order(order)
+
+    def _send_prepared_order(self, order: PreparedOverseasFuturesOrder) -> dict:
+        url = f"{self._url}/{order.path}"
+        headers = self._auth.get_header()
+        headers["tr_id"] = order.tr_id
+        resp = self._request(method=order.method, url=url, headers=headers, json=order.body)
+        return resp.json["output"]  # type: ignore[no-any-return]
+
+
+def _get_side_code(side: OrderSide) -> str:
+    if side == "sell":
+        return "01"
+    if side == "buy":
+        return "02"
+    raise KispyException(f"Invalid side: {side}")

--- a/kispy/overseas_futures/quote.py
+++ b/kispy/overseas_futures/quote.py
@@ -1,0 +1,87 @@
+"""[해외선물옵션] 기본시세."""
+
+from dataclasses import dataclass
+
+from kispy.base import BaseAPI
+from kispy.exceptions import KispyException
+
+
+@dataclass(frozen=True)
+class PreparedOverseasFuturesQuoteRequest:
+    method: str
+    path: str
+    tr_id: str
+    params: dict[str, str]
+    tr_cont: str = ""
+
+
+class QuoteAPI(BaseAPI):
+    def prepare_stock_detail(self, symbol: str) -> PreparedOverseasFuturesQuoteRequest:
+        """해외선물종목상세[v1_해외선물-008]."""
+        return PreparedOverseasFuturesQuoteRequest(
+            method="get",
+            path="uapi/overseas-futureoption/v1/quotations/stock-detail",
+            tr_id="HHDFC55010100",
+            params={"SRS_CD": symbol},
+        )
+
+    def get_stock_detail(self, symbol: str) -> dict:
+        data = self._send_prepared_quote_request(self.prepare_stock_detail(symbol))
+        return data["output1"]  # type: ignore[no-any-return]
+
+    def prepare_price(self, symbol: str) -> PreparedOverseasFuturesQuoteRequest:
+        """해외선물종목현재가[v1_해외선물-009]."""
+        return PreparedOverseasFuturesQuoteRequest(
+            method="get",
+            path="uapi/overseas-futureoption/v1/quotations/inquire-price",
+            tr_id="HHDFC55010000",
+            params={"SRS_CD": symbol},
+        )
+
+    def get_price(self, symbol: str) -> dict:
+        data = self._send_prepared_quote_request(self.prepare_price(symbol))
+        return data["output1"]  # type: ignore[no-any-return]
+
+    def prepare_orderbook(self, symbol: str) -> PreparedOverseasFuturesQuoteRequest:
+        """해외선물 호가[해외선물-031]."""
+        return PreparedOverseasFuturesQuoteRequest(
+            method="get",
+            path="uapi/overseas-futureoption/v1/quotations/inquire-asking-price",
+            tr_id="HHDFC86000000",
+            params={"SRS_CD": symbol},
+        )
+
+    def get_orderbook(self, symbol: str) -> dict:
+        data = self._send_prepared_quote_request(self.prepare_orderbook(symbol))
+        return {
+            "output1": data["output1"],
+            "output2": data["output2"],
+        }
+
+    def prepare_contract_detail(self, symbols: list[str]) -> PreparedOverseasFuturesQuoteRequest:
+        """해외선물 상품기본정보[해외선물-023]."""
+        count = len(symbols)
+        if not 1 <= count <= 32:
+            raise KispyException("종목 개수는 1개 이상 32개 이하여야 합니다.")
+
+        params = {"QRY_CNT": str(count)}
+        params.update({f"SRS_CD_{i:02d}": symbols[i - 1] if i <= count else "" for i in range(1, 33)})
+        return PreparedOverseasFuturesQuoteRequest(
+            method="get",
+            path="uapi/overseas-futureoption/v1/quotations/search-contract-detail",
+            tr_id="HHDFC55200000",
+            params=params,
+        )
+
+    def get_contract_detail(self, symbols: list[str]) -> list[dict]:
+        data = self._send_prepared_quote_request(self.prepare_contract_detail(symbols))
+        return data["output2"]  # type: ignore[no-any-return]
+
+    def _send_prepared_quote_request(self, request: PreparedOverseasFuturesQuoteRequest) -> dict:
+        url = f"{self._url}/{request.path}"
+        headers = self._auth.get_header()
+        headers["tr_id"] = request.tr_id
+        headers["tr_cont"] = request.tr_cont
+        headers["custtype"] = "P"
+        resp = self._request(method=request.method, url=url, headers=headers, params=request.params)
+        return resp.json

--- a/tests/overseas_futures/test_order.py
+++ b/tests/overseas_futures/test_order.py
@@ -1,0 +1,110 @@
+from types import SimpleNamespace
+
+import pytest
+
+from kispy.exceptions import KispyException
+from kispy.overseas_futures.order import OrderAPI
+
+
+def make_order_api(is_real: bool = True) -> OrderAPI:
+    auth = SimpleNamespace(
+        is_real=is_real,
+        cano="12345678",
+        acnt_prdt_cd="01",
+        get_header=lambda: {"authorization": "Bearer token", "appkey": "key", "appsecret": "secret"},
+    )
+    return OrderAPI(auth)
+
+
+def test_prepare_overseas_futures_buy_order_uses_official_body_shape():
+    order = make_order_api().prepare_order(
+        symbol="MNQU24",
+        side="buy",
+        quantity=2,
+        price="20000.25",
+    )
+
+    assert order.method == "post"
+    assert order.path == "uapi/overseas-futureoption/v1/trading/order"
+    assert order.tr_id == "OTFM3001U"
+    assert order.body == {
+        "CANO": "12345678",
+        "ACNT_PRDT_CD": "01",
+        "OVRS_FUTR_FX_PDNO": "MNQU24",
+        "SLL_BUY_DVSN_CD": "02",
+        "FM_LQD_USTL_CCLD_DT": "",
+        "FM_LQD_USTL_CCNO": "",
+        "PRIC_DVSN_CD": "1",
+        "FM_LIMIT_ORD_PRIC": "20000.25",
+        "FM_STOP_ORD_PRIC": "",
+        "FM_ORD_QTY": "2",
+        "FM_LQD_LMT_ORD_PRIC": "",
+        "FM_LQD_STOP_ORD_PRIC": "",
+        "CCLD_CNDT_CD": "6",
+        "CPLX_ORD_DVSN_CD": "0",
+        "ECIS_RSVN_ORD_YN": "N",
+        "FM_HDGE_ORD_SCRN_YN": "N",
+    }
+
+
+def test_prepare_overseas_futures_sell_order_uses_sell_side_code():
+    order = make_order_api().prepare_order(symbol="MNQU24", side="sell", quantity=1)
+
+    assert order.body["SLL_BUY_DVSN_CD"] == "01"
+
+
+def test_prepare_cancel_order_uses_cancel_tr_id_and_original_order_fields():
+    order = make_order_api().prepare_cancel_order(
+        order_number="0000000123",
+        order_date="20260709",
+        market_price_conversion="Y",
+    )
+
+    assert order.method == "post"
+    assert order.path == "uapi/overseas-futureoption/v1/trading/order-rvsecncl"
+    assert order.tr_id == "OTFM3003U"
+    assert order.body == {
+        "CANO": "12345678",
+        "ACNT_PRDT_CD": "01",
+        "ORGN_ORD_DT": "20260709",
+        "ORGN_ODNO": "0000000123",
+        "FM_LIMIT_ORD_PRIC": "",
+        "FM_STOP_ORD_PRIC": "",
+        "FM_LQD_LMT_ORD_PRIC": "",
+        "FM_LQD_STOP_ORD_PRIC": "",
+        "FM_HDGE_ORD_SCRN_YN": "N",
+        "FM_MKPR_CVSN_YN": "Y",
+    }
+
+
+def test_prepared_order_redacts_account_fields_for_dry_run_logs():
+    order = make_order_api().prepare_order(symbol="MNQU24", side="buy", quantity=1)
+
+    assert order.redacted_body() == {
+        **order.body,
+        "CANO": "***",
+        "ACNT_PRDT_CD": "***",
+    }
+
+
+def test_create_sends_prepared_order(monkeypatch):
+    api = make_order_api()
+    captured = {}
+
+    def fake_request(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(json={"rt_cd": "0", "output": {"ODNO": "0001"}})
+
+    monkeypatch.setattr(api, "_request", fake_request)
+
+    response = api.create(symbol="MNQU24", side="buy", quantity=1)
+
+    assert response == {"ODNO": "0001"}
+    assert captured["method"] == "post"
+    assert captured["headers"]["tr_id"] == "OTFM3001U"
+    assert captured["json"]["OVRS_FUTR_FX_PDNO"] == "MNQU24"
+
+
+def test_prepare_order_rejects_invalid_side():
+    with pytest.raises(KispyException):
+        make_order_api().prepare_order(symbol="MNQU24", side="hold", quantity=1)  # type: ignore[arg-type]

--- a/tests/overseas_futures/test_quote.py
+++ b/tests/overseas_futures/test_quote.py
@@ -1,0 +1,71 @@
+from types import SimpleNamespace
+
+import pytest
+
+from kispy.client import KisClient
+from kispy.exceptions import KispyException
+from kispy.overseas_futures.quote import QuoteAPI
+
+
+def make_quote_api(is_real: bool = True) -> QuoteAPI:
+    auth = SimpleNamespace(
+        is_real=is_real,
+        get_header=lambda: {"authorization": "Bearer token", "appkey": "key", "appsecret": "secret"},
+    )
+    return QuoteAPI(auth)
+
+
+def test_kis_client_exposes_overseas_futures_api():
+    auth = SimpleNamespace(
+        is_real=True,
+        cano="12345678",
+        acnt_prdt_cd="01",
+        account_no="12345678-01",
+        get_header=lambda: {"authorization": "Bearer token", "appkey": "key", "appsecret": "secret"},
+    )
+
+    client = KisClient(auth)
+
+    assert isinstance(client.overseas_futures.quote, QuoteAPI)
+
+
+def test_prepare_contract_detail_uses_official_symbol_parameter_slots():
+    request = make_quote_api().prepare_contract_detail(["MNQU24", "MESU24"])
+
+    assert request.method == "get"
+    assert request.path == "uapi/overseas-futureoption/v1/quotations/search-contract-detail"
+    assert request.tr_id == "HHDFC55200000"
+    assert request.params["QRY_CNT"] == "2"
+    assert request.params["SRS_CD_01"] == "MNQU24"
+    assert request.params["SRS_CD_02"] == "MESU24"
+    assert request.params["SRS_CD_03"] == ""
+    assert request.params["SRS_CD_32"] == ""
+    assert "SRS_CD_1" not in request.params
+
+
+@pytest.mark.parametrize("symbols", [[], [f"SYM{i:02d}" for i in range(33)]])
+def test_prepare_contract_detail_rejects_symbol_count_outside_official_range(symbols):
+    with pytest.raises(KispyException):
+        make_quote_api().prepare_contract_detail(symbols)
+
+
+def test_get_orderbook_preserves_summary_and_depth_outputs(monkeypatch):
+    api = make_quote_api()
+
+    def fake_request(**_kwargs):
+        return SimpleNamespace(
+            json={
+                "rt_cd": "0",
+                "output1": {"symbol": "MNQU24", "last": "20000.00"},
+                "output2": [{"askp": "20001.00", "bidp": "19999.00"}],
+            }
+        )
+
+    monkeypatch.setattr(api, "_request", fake_request)
+
+    response = api.get_orderbook("MNQU24")
+
+    assert response == {
+        "output1": {"symbol": "MNQU24", "last": "20000.00"},
+        "output2": [{"askp": "20001.00", "bidp": "19999.00"}],
+    }


### PR DESCRIPTION
## 배경
KRX-NXT probe 작업 중 기존 `kispy` dirty checkout에 해외선물옵션 SDK 후보 코드가 있었지만, SDK 경계에 맞는 재사용 가능한 wrapper인지 공식 KIS 자료와 대조가 필요했습니다. 이번 PR은 전략/실험 로직을 넣지 않고, KIS 공식 해외선물옵션 주문/기본시세 API shape에 맞춘 얇은 SDK surface만 추가합니다.

공식 기준 확인일: 2026-07-09
- KIS Developers: https://apiportal.koreainvestment.com/
- KIS official samples: https://github.com/koreainvestment/open-trading-api
- 확인한 샘플: `examples_llm/overseas_futureoption/order`, `order_rvsecncl`, `inquire_price`, `inquire_asking_price`, `stock_detail`, `search_contract_detail`

## 변경 내용
- `KisClient.overseas_futures` surface 추가
- 해외선물옵션 주문 생성/취소 prepared request builder 추가
- 해외선물옵션 종목상세, 현재가, 호가, 상품기본정보 quote request builder 추가
- `search-contract-detail`은 공식 샘플처럼 `SRS_CD_01`~`SRS_CD_32` 슬롯을 채우고, 요청 개수는 1~32개로 제한
- 호가 조회는 공식 샘플처럼 `output1`과 `output2`를 모두 보존
- 주문/시세 request shape 단위 테스트 추가

## 리뷰 포커스
- 해외선물옵션 주문 body field/TR ID가 KIS 공식 `order.py`/`order_rvsecncl.py`와 맞는지
- `search-contract-detail` 파라미터 슬롯이 `SRS_CD_01`~`SRS_CD_32`로 고정되는 방식이 사용성 측면에서도 괜찮은지
- `get_orderbook()` 반환값을 `output1/output2` dict로 보존하는 것이 SDK의 기존 반환 관례와 충돌하지 않는지
- 이번 PR에는 계좌 조회와 정정 주문은 포함하지 않음. `account.py`는 네임스페이스 자리만 열어둠

## 테스트
- `poetry run pytest tests/overseas_futures/test_order.py tests/overseas_futures/test_quote.py -q` → 11 passed
- `poetry run pytest -q` → 38 passed, 33 skipped
- `poetry run ruff check kispy/overseas_futures tests/overseas_futures kispy/client.py` → passed
- `poetry run ruff format --check kispy/overseas_futures tests/overseas_futures kispy/client.py` → passed
- `poetry run pre-commit run --all-files` → passed
